### PR TITLE
Add nostr to hs-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In order to have your domain pre-reserved, there are a few rules implemented in
   - `exit` - Tor.
   - `gnu` - GNUnet (GNS).
   - `i2p` - Invisible Internet Project.
+  - `nostr` - Nostr Protocol
   - `onion` - Tor.
   - `tor` - OnioNS.
   - `zkey` - GNS.


### PR DESCRIPTION
Would it be possible to add the [nostr](https://github.com/nostr-protocol/nostr) protocol to the list of projects working on their own TLD

We have some work in progress in this front:

- [dnstr](https://dnstr.org/)
- [NOMEN](https://github.com/ursuscamp/nomen/blob/master/docs/SPEC.md)
- [NOMEN explorer](https://nomenexplorer.com/)

Nostr is a [global network](https://nostr.watch/) of relays used for discovery and realtime updates.  We would like to build out our own SLD using our existing infrastructure.